### PR TITLE
Setting session cooke to "never" expire

### DIFF
--- a/app.js
+++ b/app.js
@@ -42,6 +42,7 @@ app.use(expressSession({
         databaseName: 'MyGiantIdeaSessionStore',
         collection: 'mySessions'
     }),
+    cookie: {expires: new Date(253402300000000)},  // Approximately Friday, 31 Dec 9999 23:59:59 GMT
     //url: 'mongodb://' + settings.username + ':' + settings.password + '@' + settings.host +':' + settings.port +'/MyGiantIdeaSessionStore'}),
     resave: false,
     saveUninitialized: false


### PR DESCRIPTION
The current session cookie expires after 2 weeks, after which the visitor needs to re-enter their visit information (email address, project and use case) - I assume we've all experienced this. This seems unnecessary, so I suggest setting an expiration date to far in the future (hence, never expiring).